### PR TITLE
Bump commons-io

### DIFF
--- a/target/classes/META-INF/maven/FreeCRMTestAutomation/FreeCRMTest/pom.xml
+++ b/target/classes/META-INF/maven/FreeCRMTestAutomation/FreeCRMTest/pom.xml
@@ -106,7 +106,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.6</version>
+			<version>2.7</version>
 		</dependency>
 
 


### PR DESCRIPTION
Bumps commons-io from 2.6 to 2.7.

Signed-off-by: dependabot[bot] <support@github.com>